### PR TITLE
Remove leading '-r -c' in windows

### DIFF
--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -60,6 +60,7 @@ module.exports.walkStack = function(minidump, symbolPaths, callback) {
 }
 
 module.exports.dumpSymbol = function(binary, callback) {
+  var args = [];
   var dumpsyms = searchCommand('dump_syms');
   if (!dumpsyms) {
     callback('Unable to find the "dump_syms"');
@@ -68,8 +69,15 @@ module.exports.dumpSymbol = function(binary, callback) {
 
   // Search for binary.dSYM on OS X.
   dsymPath = binary + '.dSYM';
-  if (process.platform == 'darwin' && fs.existsSync(dsymPath))
+  if (process.platform == 'darwin' && fs.existsSync(dsymPath)) {
     binary = dsymPath;
+  }
 
-  execute(dumpsyms, ['-r', '-c', binary], callback)
+  if (process.platform !== 'win32') {
+    args.push('-r', '-c');
+  }
+
+  args.push(binary);
+
+  execute(dumpsyms, args, callback)
 }


### PR DESCRIPTION
The windows build of `dump_syms.exe` does not take any arguments other than filenames. This fixes minidump when running in windows.
