### PR TITLE
Compile with c++11 on Linux as well

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -7,7 +7,7 @@
   'target_defaults': {
     'conditions': [
       ['OS=="linux"', {
-        'cflags': ['-w'],
+        'cflags': ['-w', '-std=c++0x'],
       }],
       ['OS=="mac"', {
         'xcode_settings': {


### PR DESCRIPTION
The new version of node-minidump does not compile on Linux as there was one flag missing to enable c++11 features.

I would have used `-std=c++11` instead of `-std=c++0x`, but for the support of older GCC version, the later one works better.

Bug reporting the issue:
https://github.com/electron/electron/issues/7892

Tested on:
OS: *Ubuntu 12.04* (old I know but had no choice)
Compiler: GCC 4.9.4