### PR TITLE
Ommit the windows condition as a temporary workaround

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,15 +3,6 @@
     {
       'target_name': 'minidump',
       'type': 'none',
-      'conditions': [
-        ['OS=="win"', {
-        }, {
-          'dependencies': [
-            'deps/breakpad/breakpad.gyp:minidump_stackwalk',
-            'deps/breakpad/breakpad.gyp:dump_syms#host',
-          ],
-        }],
-      ],
     }
   ]
 }


### PR DESCRIPTION
It's what we've done to fix it for FreeBSD
https://github.com/electron/node-minidump/issues/4