### PR TITLE
fix: add missing publish files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "README.md",
     "/bin",
     "/lib",
-    "index.d.ts"
+    "index.d.ts",
+    "build.js",
+    "deps"
   ]
 }


### PR DESCRIPTION
Seems some files are missing in the latest v0.16.0 npm tarball