### PR TITLE
feat: add .dump() for fetching raw minidump contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Add search paths for looking up symbol files.
 Get the stack trace from `minidumpFilePath`, the `callback` would be called
 with `callback(error, report)` upon completion.
 
+### minidump.dump(minidumpFilePath, callback)
+
+Parse and dump the raw contents of the minidump as text using `minidump_dump`.
+
 ### minidump.dumpSymbol(binaryPath, callback)
 
 Dump debug symbols in minidump format from `binaryPath`, the `callback` would

--- a/build.js
+++ b/build.js
@@ -14,7 +14,7 @@ spawnSync(path.join(__dirname, 'deps', 'breakpad', 'configure'), [], {
   },
   stdio: 'inherit'
 })
-const targets = ['src/processor/minidump_stackwalk']
+const targets = ['src/processor/minidump_stackwalk', 'src/processor/minidump_dump']
 if (process.platform === 'linux') {
   targets.push('src/tools/linux/dump_syms/dump_syms')
 }

--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -6,6 +6,7 @@ const format = require('./format')
 const exe = process.platform === 'win32' ? '.exe' : ''
 const commands = {
   minidump_stackwalk: path.resolve(__dirname, '..', 'build', 'src', 'processor', 'minidump_stackwalk') + exe,
+  minidump_dump: path.resolve(__dirname, '..', 'build', 'src', 'processor', 'minidump_dump') + exe,
   dump_syms: (() => {
     if (process.platform === 'darwin') {
       return path.resolve(__dirname, '..', 'build', 'src', 'tools', 'mac', 'dump_syms', 'dump_syms_mac')
@@ -73,6 +74,10 @@ module.exports.walkStack = function (minidump, symbolPaths, callback, commandArg
   var args = [minidump].concat(symbolPaths, globalSymbolPaths)
   args = commandArgs ? [commandArgs].concat(args) : args
   execute(stackwalk, args, callback)
+}
+
+module.exports.dump = function (minidump, callback, commandArgs) {
+  execute(commands.minidump_dump, [minidump].concat(commandArgs || []), callback)
 }
 
 module.exports.dumpSymbol = function (binary, callback) {

--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -28,7 +28,7 @@ function execute (command, args, callback) {
   })
   child.on('close', function (code) {
     if (code !== 0) {
-      callback(stderr ? new Error(stderr.toString()) : new Error('Command `' + command + '` failed: ' + code))
+      callback(stderr ? new Error(stderr.toString()) : new Error('Command `' + command + '` failed: ' + code), stdout)
     } else {
       callback(null, stdout)
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Read and process minidump file",
   "version": "0.19.0",
   "bin": {
-    "minidump_stackwalk": "build/src/processor/minidump_stackwalk"
+    "minidump_stackwalk": "build/src/processor/minidump_stackwalk",
+    "minidump_dump": "build/src/processor/minidump_dump"
   },
   "types": "index.d.ts",
   "license": "MIT",

--- a/test/minidump-test.js
+++ b/test/minidump-test.js
@@ -89,6 +89,17 @@ describe('minidump', function () {
     })
   })
 
+  describe('dump()', function() {
+    it('calls back with minidump info', function (done) {
+      minidump.dump(path.join(__dirname, 'fixtures', 'linux.dmp'), (err, rep) => {
+        const report = rep.toString('utf8')
+        assert.notEqual(report.length, 0)
+        assert.notEqual(report.indexOf('libXss.so.1.0.0'), -1)
+        done()
+      })
+    })
+  })
+
   describe('moduleList()', function () {
     describe('on a Linux dump', () => {
       it('calls back with a module list', function (done) {

--- a/test/minidump-test.js
+++ b/test/minidump-test.js
@@ -89,9 +89,12 @@ describe('minidump', function () {
     })
   })
 
-  describe('dump()', function() {
+  describe('dump()', function () {
     it('calls back with minidump info', function (done) {
       minidump.dump(path.join(__dirname, 'fixtures', 'linux.dmp'), (err, rep) => {
+        if (err) {
+          // do nothing, errors are fine here
+        }
         const report = rep.toString('utf8')
         assert.notEqual(report.length, 0)
         assert.notEqual(report.indexOf('libXss.so.1.0.0'), -1)


### PR DESCRIPTION
This is in order to support electron-minidump downloading symbols from linked libraries.