### PR TITLE
fix: support dump_syms on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 npm install minidump
 ```
 
-## Building
+## Building (for development)
 
 * `git clone --recurse-submodules https://github.com/electron/node-minidump`
 * `npm install`

--- a/build.js
+++ b/build.js
@@ -8,10 +8,6 @@ if (!fs.existsSync(buildDir)) {
 }
 
 let includes = `-I${path.relative(buildDir, path.join(__dirname, 'deps'))}`
-if (process.platform === 'darwin') {
-  // needed for `#include "common/*.h"` in `src/tools/mac/dump_syms/dump_syms_tool`
-  includes = includes + ` -I${path.relative(buildDir, path.join(__dirname, 'deps', 'breakpad', 'src'))}`
-}
 
 spawnSync(path.join(__dirname, 'deps', 'breakpad', 'configure'), [], {
   cwd: buildDir,
@@ -25,10 +21,13 @@ const targets = ['src/processor/minidump_stackwalk', 'src/processor/minidump_dum
 if (process.platform === 'linux') {
   targets.push('src/tools/linux/dump_syms/dump_syms')
 }
-if (process.platform === 'darwin') {
-  targets.push('src/tools/mac/dump_syms/dump_syms_tool')
-}
 
 spawnSync('make', [includes, '-C', buildDir, '-j', require('os').cpus().length, ...targets], {
   stdio: 'inherit'
 })
+
+if (process.platform === 'darwin') {
+  spawnSync('xcodebuild', ['-project', path.join(__dirname, 'deps', 'breakpad', 'src', 'tools', 'mac', 'dump_syms', 'dump_syms.xcodeproj'), 'build'], {
+    stdio: 'inherit'
+  })
+}

--- a/build.js
+++ b/build.js
@@ -1,6 +1,13 @@
 const fs = require('fs')
 const path = require('path')
-const { spawnSync } = require('child_process')
+const childProcess = require('child_process')
+
+function spawnSync(...args) {
+  const result = childProcess.spawnSync(...args)
+  if (result.status !== 0) {
+    process.exit(result.status)
+  }
+}
 
 const buildDir = path.join(__dirname, 'build')
 if (!fs.existsSync(buildDir)) {

--- a/build.js
+++ b/build.js
@@ -27,7 +27,7 @@ if (process.platform === 'linux') {
   targets.push('src/tools/linux/dump_syms/dump_syms')
 }
 
-spawnSync('make', [includes, '-C', buildDir, '-j', require('os').cpus().length, ...targets], {
+spawnSync('make', ['-C', buildDir, '-j', require('os').cpus().length, ...targets], {
   stdio: 'inherit'
 })
 

--- a/build.js
+++ b/build.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const childProcess = require('child_process')
 
-function spawnSync(...args) {
+function spawnSync (...args) {
   const result = childProcess.spawnSync(...args)
   if (result.status !== 0) {
     process.exit(result.status)

--- a/build.js
+++ b/build.js
@@ -18,6 +18,10 @@ const targets = ['src/processor/minidump_stackwalk', 'src/processor/minidump_dum
 if (process.platform === 'linux') {
   targets.push('src/tools/linux/dump_syms/dump_syms')
 }
+if (process.platform === 'darwin') {
+  targets.push('src/tools/mac/dump_syms/dump_syms_tool')
+}
+
 spawnSync('make', ['-C', buildDir, '-j', require('os').cpus().length, ...targets], {
   stdio: 'inherit'
 })

--- a/build.js
+++ b/build.js
@@ -6,11 +6,18 @@ const buildDir = path.join(__dirname, 'build')
 if (!fs.existsSync(buildDir)) {
   fs.mkdirSync(buildDir, { recursive: true })
 }
+
+let includes = `-I${path.relative(buildDir, path.join(__dirname, 'deps'))}`
+if (process.platform === 'darwin') {
+  // needed for `#include "common/*.h"` in `src/tools/mac/dump_syms/dump_syms_tool`
+  includes = includes + ` -I${path.relative(buildDir, path.join(__dirname, 'deps', 'breakpad', 'src'))}`
+}
+
 spawnSync(path.join(__dirname, 'deps', 'breakpad', 'configure'), [], {
   cwd: buildDir,
   env: {
     ...process.env,
-    CPPFLAGS: `-I${path.relative(buildDir, path.join(__dirname, 'deps'))}`
+    CPPFLAGS: includes
   },
   stdio: 'inherit'
 })
@@ -22,6 +29,6 @@ if (process.platform === 'darwin') {
   targets.push('src/tools/mac/dump_syms/dump_syms_tool')
 }
 
-spawnSync('make', ['-C', buildDir, '-j', require('os').cpus().length, ...targets], {
+spawnSync('make', [includes, '-C', buildDir, '-j', require('os').cpus().length, ...targets], {
   stdio: 'inherit'
 })

--- a/build.js
+++ b/build.js
@@ -14,13 +14,11 @@ if (!fs.existsSync(buildDir)) {
   fs.mkdirSync(buildDir, { recursive: true })
 }
 
-let includes = `-I${path.relative(buildDir, path.join(__dirname, 'deps'))}`
-
 spawnSync(path.join(__dirname, 'deps', 'breakpad', 'configure'), [], {
   cwd: buildDir,
   env: {
     ...process.env,
-    CPPFLAGS: includes
+    CPPFLAGS: `-I${path.relative(buildDir, path.join(__dirname, 'deps'))}`
   },
   stdio: 'inherit'
 })

--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -9,7 +9,7 @@ const commands = {
   minidump_dump: path.resolve(__dirname, '..', 'build', 'src', 'processor', 'minidump_dump') + exe,
   dump_syms: (() => {
     if (process.platform === 'darwin') {
-      return path.resolve(__dirname, '..', 'build', 'src', 'tools', 'mac', 'dump_syms', 'dump_syms')
+      return path.resolve(__dirname, '..', 'deps', 'breakpad', 'src', 'tools', 'mac', 'dump_syms', 'build', 'Release', 'dump_syms')
     } else if (process.platform === 'linux') {
       return path.resolve(__dirname, '..', 'build', 'src', 'tools', 'linux', 'dump_syms', 'dump_syms')
     }

--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -9,7 +9,7 @@ const commands = {
   minidump_dump: path.resolve(__dirname, '..', 'build', 'src', 'processor', 'minidump_dump') + exe,
   dump_syms: (() => {
     if (process.platform === 'darwin') {
-      return path.resolve(__dirname, '..', 'build', 'src', 'tools', 'mac', 'dump_syms', 'dump_syms_mac')
+      return path.resolve(__dirname, '..', 'build', 'src', 'tools', 'mac', 'dump_syms', 'dump_syms')
     } else if (process.platform === 'linux') {
       return path.resolve(__dirname, '..', 'build', 'src', 'tools', 'linux', 'dump_syms', 'dump_syms')
     }

--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -12,6 +12,8 @@ const commands = {
       return path.resolve(__dirname, '..', 'deps', 'breakpad', 'src', 'tools', 'mac', 'dump_syms', 'build', 'Release', 'dump_syms')
     } else if (process.platform === 'linux') {
       return path.resolve(__dirname, '..', 'build', 'src', 'tools', 'linux', 'dump_syms', 'dump_syms')
+    } else if (process.platform === 'win32') {
+      return path.resolve(__dirname, '..', 'deps', 'breakpad', 'src', 'tools', 'windows', 'binaries', 'dump_syms.exe')
     }
   })()
 }

--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -12,8 +12,6 @@ const commands = {
       return path.resolve(__dirname, '..', 'deps', 'breakpad', 'src', 'tools', 'mac', 'dump_syms', 'build', 'Release', 'dump_syms')
     } else if (process.platform === 'linux') {
       return path.resolve(__dirname, '..', 'build', 'src', 'tools', 'linux', 'dump_syms', 'dump_syms')
-    } else if (process.platform === 'win32') {
-      return path.resolve(__dirname, '..', 'deps', 'breakpad', 'src', 'tools', 'windows', 'binaries', 'dump_syms.exe')
     }
   })()
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "scripts": {
     "test": "mocha test && standard",
-    "preinstall": "node build.js"
+    "build": "node build.js",
+    "submodule": "git submodule update --recursive --init",
+    "prepare": "npm run submodule && npm run build"
   },
   "devDependencies": {
     "electron-download": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "mocha test && standard",
     "build": "node build.js",
     "submodule": "git submodule update --recursive --init",
-    "prepare": "npm run submodule && npm run build"
+    "prepare": "npm run submodule && npm run build",
+    "postinstall": "npm run build"
   },
   "devDependencies": {
     "electron-download": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,7 @@
   },
   "scripts": {
     "test": "mocha test && standard",
-    "build": "node build.js",
-    "submodule": "git submodule update --recursive --init",
-    "prepublishOnly": "npm run submodule && npm run build",
-    "postinstall": "npm run build"
+    "preinstall": "node build.js"
   },
   "devDependencies": {
     "electron-download": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha test && standard",
     "build": "node build.js",
     "submodule": "git submodule update --recursive --init",
-    "prepare": "npm run submodule && npm run build",
+    "prepublishOnly": "npm run submodule && npm run build",
     "postinstall": "npm run build"
   },
   "devDependencies": {

--- a/test/minidump-test.js
+++ b/test/minidump-test.js
@@ -74,8 +74,6 @@ describe('minidump', function () {
 
   describe('dumpSymbol()', function () {
     it('calls back with a minidump', function (done) {
-      if (process.platform !== 'linux') return this.skip()
-
       downloadElectron(function (error, binaryPath) {
         if (error) return done(error)
         minidump.dumpSymbol(binaryPath, function (error, minidump) {


### PR DESCRIPTION
This fixes the scripts:
- prepare: runs before publishing or when npm install runs in the cloned repo -> makes sure that the submodules will be included in the npm package
- postinstall -> makes sure that the build.js script runs when minidump is installed as a dependency

This is blocking electron upgrade of Atom
https://github.com/atom/atom/pull/21777