### PR TITLE
fix: chmod binaries before publishing

### DIFF
--- a/build.js
+++ b/build.js
@@ -60,11 +60,9 @@ if (!fs.existsSync(binDir)) {
 
 const minidumpStackwalk = path.resolve(__dirname, 'build', 'src', 'processor', 'minidump_stackwalk') + exe
 fs.copyFileSync(minidumpStackwalk, minidumpStackwalkDest)
-fs.chmodSync(minidumpStackwalkDest, 0o755)
 
 const minidumpDump = path.resolve(__dirname, 'build', 'src', 'processor', 'minidump_dump') + exe
 fs.copyFileSync(minidumpDump, minidumpDumpDest)
-fs.chmodSync(minidumpDumpDest, 0o755)
 
 const dumpSyms = (() => {
   if (process.platform === 'darwin') {
@@ -74,4 +72,3 @@ const dumpSyms = (() => {
   }
 })()
 fs.copyFileSync(dumpSyms, dumpSymsDest)
-fs.chmodSync(dumpSymsDest, 0o755)

--- a/build.js
+++ b/build.js
@@ -60,9 +60,11 @@ if (!fs.existsSync(binDir)) {
 
 const minidumpStackwalk = path.resolve(__dirname, 'build', 'src', 'processor', 'minidump_stackwalk') + exe
 fs.copyFileSync(minidumpStackwalk, minidumpStackwalkDest)
+fs.chmodSync(minidumpStackwalkDest, 0o755)
 
 const minidumpDump = path.resolve(__dirname, 'build', 'src', 'processor', 'minidump_dump') + exe
 fs.copyFileSync(minidumpDump, minidumpDumpDest)
+fs.chmodSync(minidumpDumpDest, 0o755)
 
 const dumpSyms = (() => {
   if (process.platform === 'darwin') {
@@ -72,3 +74,4 @@ const dumpSyms = (() => {
   }
 })()
 fs.copyFileSync(dumpSyms, dumpSymsDest)
+fs.chmodSync(dumpSymsDest, 0o755)

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
   },
   "scripts": {
     "test": "mocha test && standard",
+    "prepublishOnly": "shx chmod -R +x ./bin",
     "preinstall": "node build.js"
   },
   "devDependencies": {
     "electron-download": "^3.0.1",
     "extract-zip": "^1.5.0",
     "mocha": "^3.1.2",
+    "shx": "^0.3.3",
     "standard": "^8.4.0",
     "temp": "^0.8.3"
   },


### PR DESCRIPTION
The permissions might be lost when uploaded and downloaded again. This ensures they are executables before publishing. 


The reason: https://github.com/actions/upload-artifact#permission-loss

