### PR TITLE
fix: destructuring commandArgs

### DIFF
--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -68,7 +68,7 @@ module.exports.walkStack = function (minidump, symbolPaths, callback, commandArg
   }
 
   var args = [minidump].concat(symbolPaths, globalSymbolPaths)
-  args = commandArgs ? [commandArgs].concat(args) : args
+  args = commandArgs ? [...commandArgs].concat(args) : args
   execute(stackwalk, args, callback)
 }
 


### PR DESCRIPTION
because `commandArgs` is Array, so if `commandArgs = ["-m", "-s"];`

then the `args = [ ["-m", "-s"] ]`, and the execute not handle it, so stackwalk will fail and exit