### PR TITLE
Handle spawn 'error' event

### DIFF
--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -30,6 +30,9 @@ function execute (command, args, callback) {
       callback(null, stdout)
     }
   })
+  child.on('error', function (error) {
+    callback(error, stdout)
+  })
 }
 
 var globalSymbolPaths = []


### PR DESCRIPTION
We found that an unhandled spawn 'error' event would crash our node process despite being wrapped in try-catch. With this fix, errors were able to be caught and handled appropriately.