### PR TITLE
docs: update CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minidump - Process minidump files
 
-![CI](https://github.com/electron/node-minidump/workflows/CI/badge.svg)
+[![CI](https://github.com/electron/node-minidump/actions/workflows/CI.yml/badge.svg)](https://github.com/electron/node-minidump/actions/workflows/CI.yml)
 
 ## Installing
 


### PR DESCRIPTION
Uses the output from "Create status badge" under the workflow's page. It'll now link to the actual workflow, instead of just to the badge image.