### PR TITLE
feat: update breakpad to build on macOS 13+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           path: ./bin
   test-mac:
     macos:
-      xcode: 14.2.0
+      xcode: 14.3.1
     resource_class: macos.x86.medium.gen2
     parameters:
       node-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           path: ./bin
   test-mac:
     macos:
-      xcode: 14.0.1
+      xcode: 14.1.0
     resource_class: macos.x86.medium.gen2
     parameters:
       node-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           path: ./bin
   test-mac:
     macos:
-      xcode: 13.4.1
+      xcode: 14.0.1
     resource_class: macos.x86.medium.gen2
     parameters:
       node-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           path: ./bin
   test-mac:
     macos:
-      xcode: 14.1.0
+      xcode: 14.2.0
     resource_class: macos.x86.medium.gen2
     parameters:
       node-version:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "deps/breakpad"]
 	path = deps/breakpad
 	url = https://chromium.googlesource.com/breakpad/breakpad
+        ignore = untracked


### PR DESCRIPTION
Bumps breakpad to [the SHA currently used in Chromium](https://source.chromium.org/chromium/chromium/src/+/main:DEPS;l=1206;drc=ea122d230ee07ab72f02ef097a9099e020bfad24) to pick up fixes for building on macOS 13+.

Closes #67.