### PR TITLE
ci: bump Xcode version on release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             - bin
   release-mac:
     macos:
-      xcode: 13.4.1
+      xcode: 14.3.1
     resource_class: macos.x86.medium.gen2
     steps:
       - install:


### PR DESCRIPTION
Follow-up to #69, forgot to also update the Xcode version for the release job.