### PR TITLE
chore: add `engines.node` >= 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/electron/node-minidump.git"
   },
+  "engines": {
+    "node": ">=14"
+  },
   "bugs": {
     "url": "https://github.com/electron/node-minidump/issues"
   },


### PR DESCRIPTION
Ran `yarn test` locally on Node.js 14.21 and this worked for me. We require Node.js 14 because of Mocha 10.