### PR TITLE
build: fix repository.url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/electron/node-minidump.git"
+    "url": "git+https://github.com/electron/node-minidump.git"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
Clears this warning during publish:

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/electron/node-minidump.git"
```