### PR TITLE
fix callback called 2 or more times upon error

### DIFF
--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -14,6 +14,15 @@ const commands = {
 }
 
 function execute (command, args, callback) {
+  let called = false
+  const origCallback = callback
+  callback = function (err, stdout) {
+    if (called) {
+      return
+    }
+    called = true
+    origCallback(err, stdout)
+  }
   let stdout = Buffer.alloc(0)
   let stderr = Buffer.alloc(0)
   const child = spawn(command, args)


### PR DESCRIPTION
Callback was getting called both upon `spawn` complete as well as upon process error events (in practice was calling the callback twice if the `minidump_stackwalk` binary didn't exist / was unable to be executed)