### PR TITLE
feat!: upgrade to Node 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '18.18'
+          node-version: '22.12'
           cache: 'yarn'
       - name: Install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22.12'
+          node-version-file: .nvmrc
           cache: 'yarn'
       - name: Install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: '22.12'
           cache: 'yarn'
       - name: Install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22.12'
+          node-version-file: .nvmrc
           cache: 'yarn'
       - name: Install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,11 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '20.10'
-          - '18.18'
-          - '16.20'
-          - '14.21'
+          - '22.12'
         os:
           - macos-latest
           - ubuntu-latest
           # - windows-latest
-        exclude:
-          - os: macos-latest
-            node-version: '14.21'
     runs-on: "${{ matrix.os }}"
     steps:
       - run: git config --global core.autocrlf input

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install minidump
 ## Docs
 
 ```javascript
-var minidump = require('minidump');
+import minidump from 'minidump';
 ```
 
 ### minidump.addSymbolPath(path1, ..., pathN)

--- a/build.js
+++ b/build.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import childProcess from 'node:child_process'
 
@@ -54,7 +55,7 @@ if (process.platform === 'linux') {
   targets.push('src/tools/linux/dump_syms/dump_syms')
 }
 
-spawnSync('make', ['-C', buildDir, '-j', require('os').cpus().length, ...targets], {
+spawnSync('make', ['-C', buildDir, '-j', os.cpus().length, ...targets], {
   stdio: 'inherit'
 })
 

--- a/build.js
+++ b/build.js
@@ -1,10 +1,11 @@
-const fs = require('fs')
-const path = require('path')
-const childProcess = require('child_process')
-const { getEffectiveArch } = require('./lib/arch')
+import fs from 'node:fs'
+import path from 'node:path'
+import childProcess from 'node:child_process'
+
+import { getEffectiveArch } from './lib/arch.js'
 
 const exe = process.platform === 'win32' ? '.exe' : ''
-const binDir = path.join(__dirname, 'bin', `${process.platform}-${getEffectiveArch()}`)
+const binDir = path.join(import.meta.dirname, 'bin', `${process.platform}-${getEffectiveArch()}`)
 
 const minidumpStackwalkDest = path.join(binDir, 'minidump_stackwalk') + exe
 const minidumpDumpDest = path.join(binDir, 'minidump_dump') + exe
@@ -27,7 +28,7 @@ function spawnSync (...args) {
   }
 }
 
-const buildDir = path.join(__dirname, 'build', getEffectiveArch())
+const buildDir = path.join(import.meta.dirname, 'build', getEffectiveArch())
 if (!fs.existsSync(buildDir)) {
   fs.mkdirSync(buildDir, { recursive: true })
 }

--- a/build.js
+++ b/build.js
@@ -40,11 +40,11 @@ if (getEffectiveArch() !== process.arch && process.platform === 'darwin') {
   crossCompileHost = 'x86_64-apple-darwin20.6.0'
 }
 
-spawnSync(path.join(__dirname, 'deps', 'breakpad', 'configure'), crossCompileHost ? [`--host=${crossCompileHost}`] : [], {
+spawnSync(path.join(import.meta.dirname, 'deps', 'breakpad', 'configure'), crossCompileHost ? [`--host=${crossCompileHost}`] : [], {
   cwd: buildDir,
   env: {
     ...process.env,
-    CPPFLAGS: [`-I${path.relative(buildDir, path.join(__dirname, 'deps'))}`, ...(overrideArch ? [`-arch ${overrideArch}`] : [])].join(' '),
+    CPPFLAGS: [`-I${path.relative(buildDir, path.join(import.meta.dirname, 'deps'))}`, ...(overrideArch ? [`-arch ${overrideArch}`] : [])].join(' '),
     LDFLAGS: overrideArch ? `-arch ${overrideArch}` : undefined
   },
   stdio: 'inherit'
@@ -59,7 +59,7 @@ spawnSync('make', ['-C', buildDir, '-j', require('os').cpus().length, ...targets
 })
 
 if (process.platform === 'darwin') {
-  spawnSync('xcodebuild', ['-project', path.join(__dirname, 'deps', 'breakpad', 'src', 'tools', 'mac', 'dump_syms', 'dump_syms.xcodeproj'), 'build'], {
+  spawnSync('xcodebuild', ['-project', path.join(import.meta.dirname, 'deps', 'breakpad', 'src', 'tools', 'mac', 'dump_syms', 'dump_syms.xcodeproj'), 'build'], {
     stdio: 'inherit'
   })
 }
@@ -77,7 +77,7 @@ fs.copyFileSync(minidumpDump, minidumpDumpDest)
 
 const dumpSyms = (() => {
   if (process.platform === 'darwin') {
-    return path.resolve(__dirname, 'deps', 'breakpad', 'src', 'tools', 'mac', 'dump_syms', 'build', 'Release', 'dump_syms')
+    return path.resolve(import.meta.dirname, 'deps', 'breakpad', 'src', 'tools', 'mac', 'dump_syms', 'build', 'Release', 'dump_syms')
   } else if (process.platform === 'linux') {
     return path.resolve(buildDir, 'src', 'tools', 'linux', 'dump_syms', 'dump_syms')
   }

--- a/lib/arch.js
+++ b/lib/arch.js
@@ -1,5 +1,3 @@
-module.exports = {
-  getEffectiveArch: () => {
-    return process.env.MINIDUMP_BUILD_ARCH || process.arch
-  }
+export const getEffectiveArch = () => {
+  return process.env.MINIDUMP_BUILD_ARCH || process.arch
 }

--- a/lib/format.js
+++ b/lib/format.js
@@ -140,7 +140,7 @@ function readString (buf, rva) {
 
 // MDStreamType
 // https://chromium.googlesource.com/breakpad/breakpad/+/refs/heads/master/src/google_breakpad/common/minidump_format.h#310
-const streamTypes = {
+export const streamTypes = {
   MD_MODULE_LIST_STREAM: 4
 }
 
@@ -158,7 +158,7 @@ const streamTypeProcessors = {
   }
 }
 
-module.exports.readMinidump = function readMinidump (buf) {
+export function readMinidump (buf) {
   const header = readHeader(buf)
   if (header.signature !== headerMagic) {
     throw new Error('not a minidump file')
@@ -173,5 +173,3 @@ module.exports.readMinidump = function readMinidump (buf) {
   }
   return { header, streams }
 }
-
-module.exports.streamTypes = streamTypes

--- a/lib/minidump.js
+++ b/lib/minidump.js
@@ -1,11 +1,12 @@
-const fs = require('fs')
-const path = require('path')
-const spawn = require('child_process').spawn
-const { getEffectiveArch } = require('./arch')
-const format = require('./format')
+import fs from 'node:fs'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+
+import { getEffectiveArch } from './arch.js'
+import * as format from './format.js'
 
 const exe = process.platform === 'win32' ? '.exe' : ''
-const binDir = path.join(path.dirname(__dirname), 'bin', `${process.platform}-${getEffectiveArch()}`)
+const binDir = path.join(path.dirname(import.meta.dirname), 'bin', `${process.platform}-${getEffectiveArch()}`)
 
 const commands = {
   minidump_stackwalk: path.join(binDir, 'minidump_stackwalk') + exe,
@@ -36,9 +37,9 @@ function execute (command, args, callback) {
 }
 
 const globalSymbolPaths = []
-module.exports.addSymbolPath = Array.prototype.push.bind(globalSymbolPaths)
+export const addSymbolPath = Array.prototype.push.bind(globalSymbolPaths)
 
-module.exports.moduleList = function (minidump, callback) {
+export function moduleList (minidump, callback) {
   fs.readFile(minidump, (err, data) => {
     if (err) return callback(err)
     const { streams } = format.readMinidump(data)
@@ -59,7 +60,7 @@ module.exports.moduleList = function (minidump, callback) {
   })
 }
 
-module.exports.walkStack = function (minidump, symbolPaths, callback, commandArgs) {
+export function walkStack (minidump, symbolPaths, callback, commandArgs) {
   if (!callback) {
     callback = symbolPaths
     symbolPaths = []
@@ -76,11 +77,11 @@ module.exports.walkStack = function (minidump, symbolPaths, callback, commandArg
   execute(stackwalk, args, callback)
 }
 
-module.exports.dump = function (minidump, callback, commandArgs) {
+export function dump (minidump, callback, commandArgs) {
   execute(commands.minidump_dump, [minidump].concat(commandArgs || []), callback)
 }
 
-module.exports.dumpSymbol = function (binary, callback) {
+export function dumpSymbol (binary, callback) {
   const dumpsyms = commands.dump_syms
   if (!dumpsyms) {
     callback(new Error('Unable to find "dump_syms"'))

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "minidump",
   "description": "Read and process minidump file",
   "version": "0.0.0-development",
+  "type": "module",
   "types": "index.d.ts",
   "license": "MIT",
   "repository": {
@@ -41,5 +42,6 @@
     "build.js",
     "deps",
     "bin"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/electron/node-minidump.git"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=22.12.0"
   },
   "bugs": {
     "url": "https://github.com/electron/node-minidump/issues"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "mocha test && standard"
   },
   "devDependencies": {
-    "@electron/get": "^2.0.2",
+    "@electron/get": "^4.0.1",
     "extract-zip": "^1.5.0",
     "mocha": "^10.8.2",
     "shx": "^0.3.3",

--- a/test/minidump-test.js
+++ b/test/minidump-test.js
@@ -1,10 +1,13 @@
-const assert = require('assert')
-const path = require('path')
+import assert from 'node:assert'
+import path from 'node:path'
 
-const minidump = require('..')
-const { download, downloadArtifact } = require('@electron/get')
-const extractZip = require('extract-zip')
-const temp = require('temp').track()
+import * as minidump from '../lib/minidump.js'
+
+import { download, downloadArtifact } from '@electron/get'
+import extractZip from 'extract-zip'
+import temp from 'temp'
+
+temp.track()
 
 const describe = global.describe
 const it = global.it
@@ -18,7 +21,11 @@ describe('minidump', function () {
         downloadElectronSymbols('darwin', function (error, symbolsPath) {
           if (error) return done(error)
 
-          const dumpPath = path.join(__dirname, 'fixtures', 'mac.dmp')
+          const dumpPath = path.join(
+            import.meta.dirname,
+            'fixtures',
+            'mac.dmp'
+          )
           minidump.walkStack(dumpPath, symbolsPath, function (error, report) {
             if (error) return done(error)
 
@@ -26,7 +33,12 @@ describe('minidump', function () {
             assert.notEqual(report.length, 0)
 
             report = report.toString()
-            assert.notEqual(report.indexOf('Electron Framework!atom::(anonymous namespace)::Crash() [atom_bindings.cc : 27 + 0x0]'), -1)
+            assert.notEqual(
+              report.indexOf(
+                'Electron Framework!atom::(anonymous namespace)::Crash() [atom_bindings.cc : 27 + 0x0]'
+              ),
+              -1
+            )
             done()
           })
         })
@@ -38,7 +50,11 @@ describe('minidump', function () {
         downloadElectronSymbols('win32', function (error, symbolsPath) {
           if (error) return done(error)
 
-          const dumpPath = path.join(__dirname, 'fixtures', 'windows.dmp')
+          const dumpPath = path.join(
+            import.meta.dirname,
+            'fixtures',
+            'windows.dmp'
+          )
           minidump.walkStack(dumpPath, symbolsPath, function (error, report) {
             if (error) return done(error)
 
@@ -46,7 +62,12 @@ describe('minidump', function () {
             assert.notEqual(report.length, 0)
 
             report = report.toString()
-            assert.notEqual(report.indexOf('electron.exe!atom::`anonymous namespace\'::Crash [atom_bindings.cc : 27 + 0x0]'), -1)
+            assert.notEqual(
+              report.indexOf(
+                "electron.exe!atom::`anonymous namespace'::Crash [atom_bindings.cc : 27 + 0x0]"
+              ),
+              -1
+            )
             done()
           })
         })
@@ -58,13 +79,20 @@ describe('minidump', function () {
         downloadElectronSymbols('linux', function (error, symbolsPath) {
           if (error) return done(error)
 
-          const dumpPath = path.join(__dirname, 'fixtures', 'linux.dmp')
+          const dumpPath = path.join(
+            import.meta.dirname,
+            'fixtures',
+            'linux.dmp'
+          )
           minidump.walkStack(dumpPath, symbolsPath, function (error, report) {
             if (error) return done(error)
 
             report = report.toString()
             assert.notEqual(report.length, 0)
-            assert.notEqual(report.indexOf('electron!Crash [atom_bindings.cc : 27 + 0x0]'), -1)
+            assert.notEqual(
+              report.indexOf('electron!Crash [atom_bindings.cc : 27 + 0x0]'),
+              -1
+            )
             done()
           })
         })
@@ -89,26 +117,33 @@ describe('minidump', function () {
 
   describe('dump()', function () {
     it('calls back with minidump info', function (done) {
-      minidump.dump(path.join(__dirname, 'fixtures', 'linux.dmp'), (err, rep) => {
-        if (err) {
-          // do nothing, errors are fine here
+      minidump.dump(
+        path.join(import.meta.dirname, 'fixtures', 'linux.dmp'),
+        (err, rep) => {
+          if (err) {
+            // do nothing, errors are fine here
+          }
+          const report = rep.toString('utf8')
+          assert.notEqual(report.length, 0)
+          assert.notEqual(report.indexOf('libXss.so.1.0.0'), -1)
+          done()
         }
-        const report = rep.toString('utf8')
-        assert.notEqual(report.length, 0)
-        assert.notEqual(report.indexOf('libXss.so.1.0.0'), -1)
-        done()
-      })
+      )
     })
   })
 
   describe('moduleList()', function () {
     describe('on a Linux dump', () => {
       it('calls back with a module list', function (done) {
-        const dumpPath = path.join(__dirname, 'fixtures', 'linux.dmp')
+        const dumpPath = path.join(
+          import.meta.dirname,
+          'fixtures',
+          'linux.dmp'
+        )
         minidump.moduleList(dumpPath, (err, modules) => {
           if (err) return done(err)
           assert.notEqual(modules.length, 0)
-          assert(modules.some(m => m.name.endsWith('/electron')))
+          assert(modules.some((m) => m.name.endsWith('/electron')))
           done()
         })
       })
@@ -116,11 +151,15 @@ describe('minidump', function () {
 
     describe('on a Windows dump', () => {
       it('calls back with a module list', function (done) {
-        const dumpPath = path.join(__dirname, 'fixtures', 'windows.dmp')
+        const dumpPath = path.join(
+          import.meta.dirname,
+          'fixtures',
+          'windows.dmp'
+        )
         minidump.moduleList(dumpPath, (err, modules) => {
           if (err) return done(err)
           assert.notEqual(modules.length, 0)
-          assert(modules.some(m => m.name.endsWith('\\electron.exe')))
+          assert(modules.some((m) => m.name.endsWith('\\electron.exe')))
           done()
         })
       })
@@ -128,11 +167,11 @@ describe('minidump', function () {
 
     describe('on a macOS dump', () => {
       it('calls back with a module list', function (done) {
-        const dumpPath = path.join(__dirname, 'fixtures', 'mac.dmp')
+        const dumpPath = path.join(import.meta.dirname, 'fixtures', 'mac.dmp')
         minidump.moduleList(dumpPath, (err, modules) => {
           if (err) return done(err)
           assert.notEqual(modules.length, 0)
-          assert(modules.some(m => m.name.endsWith('/Electron Helper')))
+          assert(modules.some((m) => m.name.endsWith('/Electron Helper')))
           done()
         })
       })
@@ -142,29 +181,40 @@ describe('minidump', function () {
 
 function downloadElectron (callback) {
   download('27.1.2', {
-    cacheRoot: path.resolve(__dirname, '.cache'),
+    cacheRoot: path.resolve(import.meta.dirname, '.cache'),
     downloadOptions: {
       quiet: true
     }
-  }).then((zipPath) => {
-    const electronPath = temp.mkdirSync('node-minidump-')
-    extractZip(zipPath, { dir: electronPath }, function (error) {
-      if (error) return callback(error)
-
-      if (process.platform === 'darwin') {
-        callback(null, path.join(electronPath, 'Electron.app', 'Contents', 'MacOS', 'Electron'))
-      } else {
-        callback(null, path.join(electronPath, 'electron'))
-      }
-    })
-  }).catch((error) => {
-    callback(error)
   })
+    .then((zipPath) => {
+      const electronPath = temp.mkdirSync('node-minidump-')
+      extractZip(zipPath, { dir: electronPath }, function (error) {
+        if (error) return callback(error)
+
+        if (process.platform === 'darwin') {
+          callback(
+            null,
+            path.join(
+              electronPath,
+              'Electron.app',
+              'Contents',
+              'MacOS',
+              'Electron'
+            )
+          )
+        } else {
+          callback(null, path.join(electronPath, 'electron'))
+        }
+      })
+    })
+    .catch((error) => {
+      callback(error)
+    })
 }
 
 function downloadElectronSymbols (platform, callback) {
   downloadArtifact({
-    cacheRoot: path.resolve(__dirname, '.cache'),
+    cacheRoot: path.resolve(import.meta.dirname, '.cache'),
     version: '1.4.3', // Dumps were generated with Electron 1.4.3 x64
     arch: 'x64',
     platform,
@@ -173,13 +223,15 @@ function downloadElectronSymbols (platform, callback) {
     downloadOptions: {
       quiet: true
     }
-  }).then((zipPath) => {
-    const symbolsPath = temp.mkdirSync('node-minidump-')
-    extractZip(zipPath, { dir: symbolsPath }, function (error) {
-      if (error) return callback(error)
-      callback(null, path.join(symbolsPath, 'electron.breakpad.syms'))
-    })
-  }).catch((error) => {
-    callback(error)
   })
+    .then((zipPath) => {
+      const symbolsPath = temp.mkdirSync('node-minidump-')
+      extractZip(zipPath, { dir: symbolsPath }, function (error) {
+        if (error) return callback(error)
+        callback(null, path.join(symbolsPath, 'electron.breakpad.syms'))
+      })
+    })
+    .catch((error) => {
+      callback(error)
+    })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true,
+    "outDir": "dist",
+    "types": ["node"],
+    "declaration": true,
+    "strict": true
+  },
+  "include": ["lib"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
-"@electron/get@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.2.tgz#ae2a967b22075e9c25aaf00d5941cd79c21efd7e"
-  integrity sha512-eFZVFoRXb3GFGd7Ak7W4+6jBl9wBtiZ4AaYOse97ej6mKj5tkyO0dUnUChs1IhJZtx1BENo4/p4WUTXpi6vT+g==
+"@electron/get@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-4.0.1.tgz#0a064ccf075fddc4b056a0665dda9aab330d47b5"
+  integrity sha512-fTMFb/ZiK6xQace5YZlhT+vNR08ogat9SqpvwpaC9vD6hgx7ouz9cdcrSrFuNji4823Jmmy90/CDhJq0I4vRFA==
   dependencies:
     debug "^4.1.1"
-    env-paths "^2.2.0"
-    fs-extra "^8.1.0"
-    got "^11.8.5"
+    env-paths "^3.0.0"
+    got "^14.4.5"
+    graceful-fs "^4.2.11"
     progress "^2.0.3"
-    semver "^6.2.0"
+    semver "^7.6.3"
     sumchecker "^3.0.1"
   optionalDependencies:
     global-agent "^3.0.0"
@@ -72,56 +72,32 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sindresorhus/is@^4.0.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
-  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+"@sec-ant/readable-stream@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz#60de891bb126abfdc5410fdc6166aca065f10a0c"
+  integrity sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==
 
-"@szmarczak/http-timer@^4.0.5":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
-  integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
+"@sindresorhus/is@^7.0.1":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-7.0.2.tgz#a0df078a8d29f9741503c5a9c302de474ec8564a"
+  integrity sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw==
+
+"@szmarczak/http-timer@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-5.0.1.tgz#c7c1bf1141cdd4751b0399c8fc7b8b664cd5be3a"
+  integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
   dependencies:
-    defer-to-connect "^2.0.0"
+    defer-to-connect "^2.0.1"
 
-"@types/cacheable-request@^6.0.1":
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz#a430b3260466ca7b5ca5bfd735693b36e7a9d183"
-  integrity sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==
-  dependencies:
-    "@types/http-cache-semantics" "*"
-    "@types/keyv" "^3.1.4"
-    "@types/node" "*"
-    "@types/responselike" "^1.0.0"
-
-"@types/http-cache-semantics@*":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
-  integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
+"@types/http-cache-semantics@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
+  integrity sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
-
-"@types/keyv@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"
-  integrity sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/node@*":
-  version "20.4.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.5.tgz#9dc0a5cb1ccce4f7a731660935ab70b9c00a5d69"
-  integrity sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==
-
-"@types/responselike@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
-  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
-  dependencies:
-    "@types/node" "*"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -274,23 +250,23 @@ builtins@^5.0.1:
   dependencies:
     semver "^7.0.0"
 
-cacheable-lookup@^5.0.3:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
-  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
+cacheable-lookup@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz#3476a8215d046e5a3202a9209dd13fec1f933a27"
+  integrity sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==
 
-cacheable-request@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.4.tgz#7a33ebf08613178b403635be7b899d3e69bbe817"
-  integrity sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==
+cacheable-request@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-12.0.1.tgz#e6f473b5b76c02e72a0ec2cd44c7cfb7c751d7c5"
+  integrity sha512-Yo9wGIQUaAfIbk+qY0X4cDQgCosecfBe3V9NSyeY4qPC2SAkbCS4Xj79VP8WOzitpJUZKc/wsRCYF5ariDIwkg==
   dependencies:
-    clone-response "^1.0.2"
-    get-stream "^5.1.0"
-    http-cache-semantics "^4.0.0"
-    keyv "^4.0.0"
-    lowercase-keys "^2.0.0"
-    normalize-url "^6.0.1"
-    responselike "^2.0.0"
+    "@types/http-cache-semantics" "^4.0.4"
+    get-stream "^9.0.1"
+    http-cache-semantics "^4.1.1"
+    keyv "^4.5.4"
+    mimic-response "^4.0.0"
+    normalize-url "^8.0.1"
+    responselike "^3.0.0"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -341,13 +317,6 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
-
-clone-response@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.3.tgz#af2032aa47816399cf5f0a1d0db902f517abb8c3"
-  integrity sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==
-  dependencies:
-    mimic-response "^1.0.0"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -428,7 +397,7 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-defer-to-connect@^2.0.0:
+defer-to-connect@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
@@ -470,17 +439,10 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
-
-env-paths@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
-  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+env-paths@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-3.0.0.tgz#2f1e89c2f6dbd3408e1b1711dd82d62e317f58da"
+  integrity sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -843,14 +805,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+form-data-encoder@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-4.1.0.tgz#497cedc94810bd5d53b99b5d4f6c152d5cbc9db2"
+  integrity sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -901,12 +859,13 @@ get-stdin@^8.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
   integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
 
-get-stream@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
-  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+get-stream@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-9.0.1.tgz#95157d21df8eb90d1647102b63039b1df60ebd27"
+  integrity sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==
   dependencies:
-    pump "^3.0.0"
+    "@sec-ant/readable-stream" "^0.4.1"
+    is-stream "^4.0.1"
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -979,29 +938,29 @@ globalthis@^1.0.1:
   dependencies:
     define-properties "^1.1.3"
 
-got@^11.8.5:
-  version "11.8.6"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
-  integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
+got@^14.4.5:
+  version "14.4.7"
+  resolved "https://registry.yarnpkg.com/got/-/got-14.4.7.tgz#f23644b9bc16d6f35fafdf410c18116614b922dd"
+  integrity sha512-DI8zV1231tqiGzOiOzQWDhsBmncFW7oQDH6Zgy6pDPrqJuVZMtoSgPLLsBZQj8Jg4JFfwoOsDA8NGtLQLnIx2g==
   dependencies:
-    "@sindresorhus/is" "^4.0.0"
-    "@szmarczak/http-timer" "^4.0.5"
-    "@types/cacheable-request" "^6.0.1"
-    "@types/responselike" "^1.0.0"
-    cacheable-lookup "^5.0.3"
-    cacheable-request "^7.0.2"
+    "@sindresorhus/is" "^7.0.1"
+    "@szmarczak/http-timer" "^5.0.1"
+    cacheable-lookup "^7.0.0"
+    cacheable-request "^12.0.1"
     decompress-response "^6.0.0"
-    http2-wrapper "^1.0.0-beta.5.2"
-    lowercase-keys "^2.0.0"
-    p-cancelable "^2.0.0"
-    responselike "^2.0.0"
+    form-data-encoder "^4.0.2"
+    http2-wrapper "^2.2.1"
+    lowercase-keys "^3.0.0"
+    p-cancelable "^4.0.1"
+    responselike "^3.0.0"
+    type-fest "^4.26.1"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.6:
+graceful-fs@^4.1.15:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.2.0:
+graceful-fs@^4.2.11:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1052,18 +1011,18 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-http-cache-semantics@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
-  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
+http-cache-semantics@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
 
-http2-wrapper@^1.0.0-beta.5.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
-  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+http2-wrapper@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-2.2.1.tgz#310968153dcdedb160d8b72114363ef5fce1f64a"
+  integrity sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==
   dependencies:
     quick-lru "^5.1.1"
-    resolve-alpn "^1.0.0"
+    resolve-alpn "^1.2.0"
 
 ignore@^5.1.1, ignore@^5.2.0:
   version "5.2.1"
@@ -1222,6 +1181,11 @@ is-shared-array-buffer@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
+is-stream@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-4.0.1.tgz#375cf891e16d2e4baec250b85926cffc14720d9b"
+  integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
+
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
@@ -1307,13 +1271,6 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
@@ -1322,10 +1279,10 @@ jsonfile@^4.0.0:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
-keyv@^4.0.0:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.3.tgz#00873d2b046df737963157bd04f294ca818c9c25"
-  integrity sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==
+keyv@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
 
@@ -1383,10 +1340,10 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lowercase-keys@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
-  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+lowercase-keys@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
+  integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -1402,15 +1359,15 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
-mimic-response@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
-  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
-
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
+mimic-response@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
+  integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
 
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
   version "3.1.2"
@@ -1484,10 +1441,10 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-normalize-url@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
-  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+normalize-url@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-8.0.2.tgz#3b343a42f837e4dae2b01917c04e8de3782e9170"
+  integrity sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -1549,7 +1506,7 @@ object.values@^1.1.5, object.values@^1.1.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -1568,10 +1525,10 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-p-cancelable@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
-  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
+p-cancelable@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-4.0.1.tgz#2d1edf1ab8616b72c73db41c4bc9ecdd10af640e"
+  integrity sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==
 
 p-limit@^2.0.0:
   version "2.3.0"
@@ -1693,14 +1650,6 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -1774,7 +1723,7 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-resolve-alpn@^1.0.0:
+resolve-alpn@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
   integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
@@ -1811,12 +1760,12 @@ resolve@^2.0.0-next.3:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-responselike@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.1.tgz#9a0bc8fdc252f3fb1cca68b016591059ba1422bc"
-  integrity sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==
+responselike@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-3.0.0.tgz#20decb6c298aff0dbee1c355ca95461d42823626"
+  integrity sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==
   dependencies:
-    lowercase-keys "^2.0.0"
+    lowercase-keys "^3.0.0"
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -1880,7 +1829,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
-semver@^6.2.0, semver@^6.3.0:
+semver@^6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -1891,6 +1840,11 @@ semver@^7.0.0, semver@^7.3.2, semver@^7.3.8:
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.3:
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 serialize-error@^7.0.1:
   version "7.0.1"
@@ -2115,6 +2069,11 @@ type-fest@^0.3.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
 
+type-fest@^4.26.1:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -2129,11 +2088,6 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
-
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
BREAKING CHANGE: This PR bumps the minimum Node.js version to 22.12.0. This package is now ESM-only.

See more details here: https://www.electronjs.org/blog/ecosystem-node-22