### PR TITLE
ci: fix zizmor audit findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,17 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
 
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
 
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
       - run: git config --global core.autocrlf input
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:


### PR DESCRIPTION
Fixes zizmor audit findings surfaced in the latest scheduled audit run.

Changes:
- `dependabot.yml`: add 7-day cooldown for github-actions updates (auto-fix)
- `build.yml` / `test.yml`: set `persist-credentials: false` on `actions/checkout` (artipacked)
- `release.yml`: add top-level `permissions: {}` and explicit `contents: read` for the reusable `test`/`build` job calls (excessive-permissions)

Remaining finding (left as-is):
- `dangerous-triggers` on `add-to-project.yml` — `pull_request_target` is required so the workflow can authenticate as a GitHub App and add newly opened PRs/issues to the Ecosystem WG project board. The workflow only listens for `types: opened`, runs with `permissions: {}`, and never checks out PR-controlled code, so the typical `pull_request_target` risk does not apply.

cc @dsanders11