### PR TITLE
ci: suppress dangerous-triggers on add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request_target: # zizmor: ignore[dangerous-triggers] add-to-project never checks out PR code, has empty permissions, only fires on opened
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - opened
 

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] add-to-project never checks out PR code, has empty permissions, only fires on opened
     types:
       - opened
 


### PR DESCRIPTION
Follow-up to #145 — adds inline zizmor suppression for the dangerous-triggers audit on add-to-project.yml so future audits stay clean. The workflow doesn't check out PR code, has empty permissions, and only fires on opened.

cc @dsanders11